### PR TITLE
The logo.svg in App.vue was not displaying due to an incorrect path.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -11,7 +11,7 @@
 <v-spacer />
       <div class="d-flex align-center">
         <!-- 使用修正後的 src 路徑 -->
-        <v-img src="public/icons/LOGO.svg"
+        <v-img src="/icons/LOGO.svg"
        max-height="60"
        contain
        class="mr-2"


### PR DESCRIPTION
I've modified the src path of logo.svg in the v-img component from 'public/icons/logo.svg' to '/icons/logo.svg' to ensure the image loads correctly from the website's root directory.